### PR TITLE
refine VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,34 +1,57 @@
 {
+  // Workspace recommendations must use publisher.extension identifiers.
+  // Version-qualified identifiers are not supported in this file.
+  // Pin approved versions with the organization-level extensions.allowed setting
+  // or the AllowedExtensions enterprise policy.
+  // https://code.visualstudio.com/docs/enterprise/extensions#_configure-allowed-extensions
   "recommendations": [
+    // Build and shell tooling
     "ms-vscode.makefile-tools",
     "ms-vscode.powershell",
+    "timonwong.shellcheck",
+    "foxundermoon.shell-format",
+
+    // Python development
     "ms-python.python",
     "ms-python.debugpy",
     "ms-python.pylint",
     "ms-python.vscode-pylance",
     "ms-python.black-formatter",
+
+    // Remote development
     "ms-vscode-remote.remote-ssh",
     "ms-vscode-remote.remote-containers",
     "ms-vscode.remote-server",
     "ms-vscode.remote-explorer",
     "ms-vscode-remote.remote-wsl",
+
+    // Containers and orchestration
     "ms-kubernetes-tools.vscode-kubernetes-tools",
     "ms-azuretools.vscode-containers",
-    "ms-azuretools.vscode-docker",
-    "github.vscode-github-actions",
     "docker.docker",
-    "redhat.vscode-yaml",
-    "sonarsource.sonarlint-vscode",
-    "editorconfig.editorconfig",
+
+    // Source control and CI
+    "github.vscode-github-actions",
     "vivaxy.vscode-conventional-commits",
-    "esbenp.prettier-vscode",
-    "timonwong.shellcheck",
-    "foxundermoon.shell-format",
+
+    // Configuration, policy, and analysis
+    "redhat.vscode-yaml",
     "zainchen.json",
+    "tsandall.opa",
+    "editorconfig.editorconfig",
+    "sonarsource.sonarlint-vscode",
+
+    // Formatting and documentation
+    "esbenp.prettier-vscode",
     "yzhang.markdown-all-in-one",
     "davidanson.vscode-markdownlint",
-    "alefragnani.project-manager",
-    "tsandall.opa",
-    "mermaidchart.vscode-mermaid-chart"
+    "mermaidchart.vscode-mermaid-chart",
+
+    // Workspace management
+    "alefragnani.project-manager"
+  ],
+  "unwantedRecommendations": [
+    // The Docker extension is now a wrapper around Container Tools.
+    "ms-azuretools.vscode-docker"
   ]
 }


### PR DESCRIPTION
## Summary

- clarify that `.vscode/extensions.json` contains workspace recommendations rather than version pins
- document `extensions.allowed` / `AllowedExtensions` as the enterprise enforcement mechanism
- group extension recommendations by development concern for maintainability
- remove the redundant Docker extension pack from recommendations and mark it unwanted while retaining Container Tools and Docker DX

## Rationale

VS Code requires workspace recommendations to use unversioned `publisher.extension` identifiers. Approved extension versions should instead be enforced through the organization-level `extensions.allowed` setting or the `AllowedExtensions` enterprise policy.

The legacy `ms-azuretools.vscode-docker` extension is now an extension pack around Container Tools, which is already recommended directly. Keeping the pack would create a redundant recommendation.

## Validation

- verified the resulting file as valid JSONC
- verified that all recommendation entries retain the required `publisher.extension` format
- verified that only `.vscode/extensions.json` is changed