### PR TITLE
chore: refine Renovate DX workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,13 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Renovate
-        uses: sentenz/actions/renovate@62c4352acdd45163bd10ae248b71c6ad6a99e3c3 # 1.4.1
+        uses: sentenz/actions/renovate@99935197a6935a691cb151a3e469f1a969bf7714 # 1.4.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_CONFIG_VALIDATION_ERROR: "true"

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -125,12 +125,6 @@
       "matchManagers": [
         "devcontainer"
       ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "digest"
-      ],
       "groupName": "devcontainer dependencies",
       "groupSlug": "devcontainer-dependencies",
       "semanticCommits": "enabled",

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "rebaseWhen": "auto",
+  "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "internalChecksFilter": "strict",
@@ -11,6 +11,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "ignorePaths": [
+    "**/vendor/**",
     "**/node_modules/**",
     "**/bower_components/**",
     "**/charts/**",
@@ -21,6 +22,11 @@
     "ignorePaths": [
       "tests/**",
       "**/tests/**"
+    ]
+  },
+  "devcontainer": {
+    "managerFilePatterns": [
+      "/^\\.devcontainer/[^/]+/devcontainer\\.json$/"
     ]
   },
   "labels": [
@@ -36,10 +42,11 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update versioned container image references in GitHub Actions files",
+      "description": "Update versioned Docker image references in GitHub Action metadata.",
       "managerFilePatterns": [
         "**/action.{yml,yaml}"
       ],
+      "matchStringsStrategy": "any",
       "matchStrings": [
         "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
@@ -49,23 +56,31 @@
     },
     {
       "customType": "regex",
-      "description": "Update versioned container image references in Makefiles",
+      "description": "Update versioned Docker image references in Makefiles.",
       "managerFilePatterns": [
         "**/[Mm]akefile",
         "**/GNUMakefile",
         "**/*.mk"
       ],
+      "matchStringsStrategy": "any",
       "matchStrings": [
-        "(?<depName>(?:(?:docker\\.io|ghcr\\.io|quay\\.io|gcr\\.io|mcr\\.microsoft\\.com|registry\\.gitlab\\.com|cgr\\.dev|oci\\.io)/)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
-      "autoReplaceStringTemplate": "{{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{else}}{{#if currentDigest}}@{{currentDigest}}{{/if}}{{/if}}",
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{else}}{{#if currentDigest}}@{{{currentDigest}}}{{/if}}{{/if}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
     {
-      "description": "Introduces breaking changes or requires code adjustments due to changes in public APIs.",
+      "description": "Group major updates.",
+      "matchManagers": [
+        "!devcontainer",
+        "!github-actions"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "major"
       ],
@@ -74,7 +89,14 @@
       "automerge": false
     },
     {
-      "description": "Introduces backward-compatible functionality improvements and feature additions.",
+      "description": "Group minor updates.",
+      "matchManagers": [
+        "!devcontainer",
+        "!github-actions"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "minor"
       ],
@@ -83,7 +105,14 @@
       "automerge": false
     },
     {
-      "description": "Introduces backward-compatible bug fixes and small corrections.",
+      "description": "Group patch updates.",
+      "matchManagers": [
+        "!devcontainer",
+        "!github-actions"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "patch"
       ],
@@ -92,10 +121,38 @@
       "automerge": false
     },
     {
-      "description": "Container image digest bumps across Dockerfiles and Containerfiles.",
+      "description": "Group Dev Container dependency updates.",
       "matchManagers": [
-        "dockerfile",
-        "containerfile"
+        "devcontainer"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "groupName": "devcontainer dependencies",
+      "groupSlug": "devcontainer-dependencies",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Pin Dockerfile and Containerfile images to immutable digests.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group Dockerfile and Containerfile image updates.",
+      "matchManagers": [
+        "dockerfile"
       ],
       "matchDatasources": [
         "docker"
@@ -106,12 +163,24 @@
         "patch",
         "digest"
       ],
-      "groupName": "container digests",
-      "groupSlug": "container-digests",
+      "pinDigests": true,
+      "groupName": "dockerfile container images",
+      "groupSlug": "dockerfile-container-images",
       "automerge": false
     },
     {
-      "description": "Container image tag and digest updates in Makefiles.",
+      "description": "Pin custom-manager Docker images to immutable digests.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group Docker image updates in Makefiles.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -129,12 +198,13 @@
         "patch",
         "digest"
       ],
+      "pinDigests": true,
       "groupName": "makefile container images",
       "groupSlug": "makefile-container-images",
-      "automerge": false
+      "automerge": true
     },
     {
-      "description": "Container image tag and digest updates in GitHub Actions files.",
+      "description": "Group Docker image updates in GitHub Action metadata.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -150,12 +220,67 @@
         "patch",
         "digest"
       ],
-      "groupName": "github actions container images",
-      "groupSlug": "github-actions-container-images",
-      "automerge": false,
+      "pinDigests": true,
+      "groupName": "github actions metadata container images",
+      "groupSlug": "github-actions-metadata-container-images",
       "semanticCommits": "enabled",
       "semanticCommitType": "ci",
-      "semanticCommitScope": "deps"
+      "semanticCommitScope": "deps",
+      "automerge": true
+    },
+    {
+      "description": "Group non-container GitHub Actions dependency updates.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "action",
+        "uses-with",
+        "github-runner"
+      ],
+      "groupName": "github actions dependencies",
+      "groupSlug": "github-actions-dependencies",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Pin Docker images used by GitHub Actions to immutable digests.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "docker",
+        "container",
+        "service"
+      ],
+      "pinDigests": true,
+      "automerge": true
+    },
+    {
+      "description": "Group Docker image updates used by GitHub Actions.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "docker",
+        "container",
+        "service"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "pinDigests": true,
+      "groupName": "github actions container images",
+      "groupSlug": "github-actions-container-images",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Refine the DX Renovate configuration using `template-terraform` as the baseline while preserving and extending DX-specific dependency handling.

## Changes

- align core Renovate behavior with the Terraform template:
  - use `rebaseWhen: behind-base-branch`
  - ignore vendored dependencies
  - prevent generic semver groups from absorbing Docker dependencies
  - pin Dockerfile/Containerfile and custom-manager images to immutable digests
  - group and automerge Makefile container-image updates
- preserve DX GitHub Action metadata image extraction, while tightening the regex manager configuration with `matchStringsStrategy: any` and consistent replacement templates
- explicitly match nested `.devcontainer/<language>/devcontainer.json` files and group Dev Container dependencies separately without forcing digest pinning
- separate normal GitHub Actions dependencies (`action`, `uses-with`, `github-runner`) from Docker-backed GitHub Actions dependencies (`docker`, `container`, `service`)
- keep Docker-backed GitHub Actions images digest-pinned and grouped with `ci(deps)` semantic commits
- update the Renovate workflow to `sentenz/actions/renovate` 1.4.2
- reduce the workflow permission from `contents: write` to `contents: read`
- enable `RENOVATE_CONFIG_VALIDATION_ERROR=true` so invalid Renovate configuration fails the job
- preserve the existing Saturday 18:00 DX schedule

## Rationale

The previous DX configuration had several policy gaps compared with the Terraform template: broad major/minor/patch groups also matched Docker dependencies, container images were not explicitly pinned, the Renovate runner was one version behind, and invalid configuration was not fatal.

DX also has repository-specific requirements that should not be copied from Terraform verbatim. Its Dev Container definitions live under `.devcontainer/<language>/devcontainer.json`, which is outside Renovate's default Dev Container file patterns. This change explicitly enables those files and groups Dev Container updates without digest pinning, consistent with Renovate's own Docker pinning preset behavior.

Normal repository-based GitHub Action references are also separated from Docker-backed GitHub Actions dependencies so they do not fall into the generic semver groups.

## Validation

- branch is based on current `main`
- only `renovate.jsonc` and `.github/workflows/renovate.yml` are changed
- resulting Renovate JSON parses successfully
- verified the nested Dev Container matcher against the current `cpp`, `dotnet`, `go`, and `python` paths
- verified the custom regexes against representative current Makefile images and single-name action metadata images
- checked current Renovate documentation for Dev Container file matching, Docker digest pinning behavior, Dockerfile manager naming, and GitHub Actions dependency types
- attempted the packaged Renovate config validator locally; package retrieval did not complete in the execution environment, so strict validation is also enforced by the updated Renovate workflow
